### PR TITLE
Odido: Removed the clip-path

### DIFF
--- a/icons/1_Primary/Odido.svg
+++ b/icons/1_Primary/Odido.svg
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
- <defs>
-  <clipPath id="clip0_1843_36607">
-   <rect width="93.6" height="24" fill="#fff"/>
-  </clipPath>
- </defs>
  <circle cx="512" cy="512" r="512" style="fill:#56595b"/>
  <g transform="matrix(7.3974 0 0 7.3974 164.37 421.4)" style="fill:none">
-  <g clip-path="url(#clip0_1843_36607)" fill="#fff">
+  <g fill="#fff">
    <path d="m81.6 24c6.6274 0 12-5.3726 12-12s-5.3726-12-12-12-12 5.3726-12 12 5.3726 12 12 12z"/>
    <path d="m12 24c6.6274 0 12-5.3726 12-12s-5.3726-12-12-12-12 5.3726-12 12 5.3726 12 12 12z"/>
    <path d="m26.4 24c6.6272 0 12-5.3728 12-12s-5.3728-12-12-12z"/>


### PR DESCRIPTION
I don't think the clip-path is needed. It doesn't seem to change the rendered output at all.